### PR TITLE
Ignore build branches in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ cache:
   yarn: true
   directories:
   - node_modules
+branches:
+  except:
+  - build
+  - latest
 script:
 - yarn lint
 - yarn build


### PR DESCRIPTION
Travis recently removed the "Build only if .travis.yml is present". We have to
patch .travis.yml to ignore build branches.